### PR TITLE
When a resource throws an error, log it

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for Perl extension Web::Machine
 
 {{$NEXT}
+    - when a resource throws an error, log this to the logger defined in the
+      Plack::Request object if one is available (Dave Rolsky)
+
+0.05 Mon. Oct. 29th, 2012
     - if a resource returned undef from is_authorized this caused an
       uninitialized value warning (Dave Rolsky)
 

--- a/lib/Web/Machine/FSM.pm
+++ b/lib/Web/Machine/FSM.pm
@@ -98,6 +98,11 @@ sub run {
         # We should be I18N the errors
         # - SL
         warn $_ if $DEBUG;
+
+        if ( $request->logger ) {
+            $request->logger->( { level => 'error', message => $_ } );
+        }
+
         $response->status( 500 );
 
         # NOTE:

--- a/t/011-resource-500-logging.t
+++ b/t/011-resource-500-logging.t
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use lib 't/010-resources/';
+
+use Test::More;
+use Test::Fatal;
+
+use Plack::Request;
+use Plack::Response;
+
+use Web::Machine::FSM;
+
+{
+    package Throw500;
+
+    use base 'Web::Machine::Resource';
+
+    sub service_available {
+        die "This is a 500 error\n";
+    }
+}
+
+my $fsm = Web::Machine::FSM->new();
+
+my @errors;
+my $logger = sub { push @errors, @_ };
+
+my $request = Plack::Request->new( { 'psgix.logger' => $logger } );
+
+my $r = Throw500->new(
+    request  => $request,
+    response => Plack::Response->new
+);
+
+is(
+    exception { $fsm->run($r) },
+    undef,
+    'no exception from resource which throws an error'
+);
+
+is_deeply(
+    \@errors,
+    [ { level => 'error', message => "This is a 500 error\n" } ],
+    'psgix.logger is called with error message'
+);
+
+done_testing;


### PR DESCRIPTION
By default it swallows the error entirely which is kind of annoying.
