### PR TITLE
Fixes Pod error in Web::Machine::Resource

### DIFF
--- a/lib/Web/Machine/Resource.pm
+++ b/lib/Web/Machine/Resource.pm
@@ -235,7 +235,7 @@ an ARRAY ref of strings in all capitals.
 
 Defaults to C<['GET','HEAD']>.
 
-=items C<known_methods>
+=item C<known_methods>
 
 HTTP methods that are known to the resource. Like C<allowed_methods>,
 this must return an ARRAY ref of strings in all capitals. One could


### PR DESCRIPTION
MetaCPAN now displays warnings about Pod errors. For this error, scroll to the bottom of https://metacpan.org/module/STEVAN/Web-Machine-0.05/lib/Web/Machine/Resource.pm
