### PR TITLE
Added failing test for 500 received with malformed auth header.

### DIFF
--- a/t/malformed_auth.t
+++ b/t/malformed_auth.t
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+use HTTP::Request;
+use Plack::Test;
+use Plack::Util;
+use Test::More;
+
+test_psgi
+    Plack::Util::load_psgi("$FindBin::Bin/../examples/hello-world/app.psgi"),
+  sub {
+    my $cb = shift;
+    my $req = HTTP::Request->new( 'GET', '/' );
+    $req->header( Authorization => 'Basic' );
+
+    my $res = $cb->($req);
+    isnt( $res->code, 500, 'did not return 500' );
+};
+
+done_testing;


### PR DESCRIPTION
Failing test for https://rt.cpan.org/Ticket/Display.html?id=84232.
