### PR TITLE
Automaticaly load resources

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    MISC:
+        - Automatically load resources (Arthur Axel fREW Schmidt)
+
 0.11 Wed. May. 01, 2013
 
     NEW FEATURES:

--- a/lib/Web/Machine.pm
+++ b/lib/Web/Machine.pm
@@ -7,6 +7,7 @@ use warnings;
 use Try::Tiny;
 use Carp         qw[ confess ];
 use Scalar::Util qw[ blessed ];
+use Module::Runtime qw[ use_package_optimistically ];
 
 use Plack::Request;
 use Plack::Response;
@@ -21,7 +22,7 @@ sub new {
 
     (exists $args{'resource'}
         && (not blessed $args{'resource'})
-            && $args{'resource'}->isa('Web::Machine::Resource'))
+            && use_package_optimistically($args{'resource'})->isa('Web::Machine::Resource'))
                 || confess 'You must pass in a resource for this Web::Machine';
 
     $class->SUPER::new( \%args );


### PR DESCRIPTION
If you look at the commit the pros and cons should be pretty obvious.  Loading a named resource in a real application kinda blows, but this makes users need to know a little something extra if they want to define their resources inline.
