### PR TITLE
Add missing ;authordep for pod-weaver plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,6 +5,8 @@ copyright_holder = Infinity Interactive, Inc.
 
 version = 0.11
 
+;authordep Pod::Weaver::Section::Contributors
+
 [@Basic]
 
 [InstallGuide]


### PR DESCRIPTION
Just makes it easier to do things like `dzil authordeps | cpanm` and then `dzil listdeps | cpanm`
