### PR TITLE
Calculate Content-Length of the filtered body

### DIFF
--- a/lib/Web/Machine/FSM.pm
+++ b/lib/Web/Machine/FSM.pm
@@ -130,6 +130,7 @@ sub filter_response {
     for my $filter (@$filters) {
         if (ref($body) eq 'ARRAY') {
             $response->body( [ map { $filter->($_) } @$body ] );
+            $body = $response->body;
         }
         else {
             my $old_body = $body;

--- a/t/022-body-encoding.t
+++ b/t/022-body-encoding.t
@@ -8,6 +8,7 @@ use Test::More;
 use Encode qw( decode is_utf8 );
 use HTTP::Message::PSGI;
 use HTTP::Request::Common qw( GET );
+use Plack::Util;
 
 use Web::Machine;
 
@@ -212,6 +213,14 @@ sub test_charset {
         $args{bytes},
         "body contains the expected $args{charset} bytes - $args{description}"
     );
+
+    unless ($args{stream}) {
+        is(
+            Plack::Util::header_get($response->[1], "content-length"),
+            scalar @{$args{bytes}},
+            "content-length matches the expected number of $args{charset} bytes - $args{description}"
+        );
+    }
 }
 
 sub test_encoding {


### PR DESCRIPTION
Otherwise lengths will be incorrect when the body is encoded.

As noted in c4a7d7c, updating $body doesn't change what the client will
see.  It _does_ ensure we're looking at the filtered content when
calculating Content-Length, however.
