### PR TITLE
ensure closed-over $resource variable is weak

### DIFF
--- a/lib/Web/Machine/Util/BodyEncoding.pm
+++ b/lib/Web/Machine/Util/BodyEncoding.pm
@@ -4,6 +4,7 @@ package Web::Machine::Util::BodyEncoding;
 use strict;
 use warnings;
 
+use Scalar::Util qw/ weaken isweak /;
 use Encode ();
 use Web::Machine::Util qw[ first pair_key pair_value ];
 
@@ -46,6 +47,7 @@ sub encode_body {
     push @{ $resource->request->env->{'web.machine.content_filters'} ||= [] },
         sub {
             my $chunk = shift;
+            weaken $resource unless isweak $resource;
             return unless defined $chunk;
             return $resource->$encoder($resource->$charsetter($chunk));
         };


### PR DESCRIPTION
[cafe@cafepc][~/workspace/Sandbox/Web-Machine-0.12]$ PLACK_SERVER=Standalone plackup -I lib examples/env-resource/app.psgi 
HTTP::Server::PSGI: Accepting connections at http://0:5000/
Unhandled type: GLOB at /home/cafe/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Devel/Cycle.pm line 107.
Cycle (1):
    $A->{'web.machine.content_filters'} => \@B  
                           $B->[0] => &C  
             $C variable $resource => \$D  
                               $$D => \%Env::Resource::E  
    $Env::Resource::E->{'request'} => \%Plack::Request::F  
       $Plack::Request::F->{'env'} => \%A  
