### PR TITLE
Catch and log exceptions that happen in finish_request

### DIFF
--- a/lib/Web/Machine/FSM.pm
+++ b/lib/Web/Machine/FSM.pm
@@ -111,7 +111,18 @@ sub run {
 
     $self->filter_response( $resource )
         unless $request->env->{'web.machine.streaming_push'};
-    $resource->finish_request( $metadata );
+    try {
+        $resource->finish_request( $metadata );
+    }
+    catch {
+        warn $_ if $DEBUG;
+
+        if ( $request->logger ) {
+            $request->logger->( { level => 'error', message => $_ } );
+        }
+
+        $response->status( 500 );
+    };
     $response->header( $self->tracing_header, (join ',' => @trace) )
         if $tracing;
 

--- a/t/013-finish-request-logging.t
+++ b/t/013-finish-request-logging.t
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use lib 't/010-resources/';
+
+use Test::More;
+use Test::Fatal;
+
+use Plack::Request;
+use Plack::Response;
+
+use Web::Machine::FSM;
+
+{
+    package DieInFinishRequest;
+
+    use base 'Web::Machine::Resource';
+
+    sub known_methods { [qw[ GET ]] }
+
+    sub finish_request {
+        die "Something bad happened\n";
+    }
+}
+
+my $fsm = Web::Machine::FSM->new();
+
+my @errors;
+my $logger = sub { push @errors, @_ };
+
+my $request = Plack::Request->new( { 'psgix.logger' => $logger } );
+
+my $r = DieInFinishRequest->new(
+    request  => $request,
+    response => Plack::Response->new
+);
+
+is(
+    exception { $fsm->run($r) },
+    undef,
+    'no exception from resource which throws an error'
+);
+
+is_deeply(
+    \@errors,
+    [ { level => 'error', message => "Something bad happened\n" } ],
+    'psgix.logger is called with error message'
+);
+
+done_testing;


### PR DESCRIPTION
This PR catches and logs exceptions that happen in `finish_request`. This prevents the exception from falling back to the PSGI servers, most of which have horrible support for properly logging errors.
