### PR TITLE
Documentation update

### DIFF
--- a/lib/Web/Machine.pm
+++ b/lib/Web/Machine.pm
@@ -170,12 +170,15 @@ set forward by that module.
 =item C<< new( resource => $resource_classname, ?resource_args => $arg_list, ?tracing => 1|0, ?streaming => 1|0 ) >>
 
 The constructor expects to get a C<$resource_classname>, which it will use to
-create an instance of the resource class. If that class requires any additional
-arguments, they can be specified with the C<resource_args> parameter. It can
-also take an optional C<tracing> parameter which it will pass onto the
-L<Web::Machine::FSM>, and an optional C<streaming> parameter, which if true
-will run the request in a L<PSGI|http://plackperl.org/> streaming response, which can be useful if
-you need to run your content generation asynchronously.
+load and create an instance of the resource class. If that class requires any
+additional arguments, they can be specified with the C<resource_args>
+parameter. The contents of the C<resource_args> parameter will be made
+available to the C<init()> method of C<Web::Machine::Resource>.
+
+C<new> can also take an optional C<tracing> parameter which it will pass onto
+the L<Web::Machine::FSM>, and an optional C<streaming> parameter, which if true
+will run the request in a L<PSGI|http://plackperl.org/> streaming response,
+which can be useful if you need to run your content generation asynchronously.
 
 =item C<inflate_request( $env )>
 


### PR DESCRIPTION
- Clarify use of Web::Machine resource_args constructor argument.
- Expand the Description and resource_args sections of
  Web::Machine::Resource.
- Fix minor typos.
