### PR TITLE
Constructor can accept request class name

### DIFF
--- a/t/003-request-class.t
+++ b/t/003-request-class.t
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+
+use Web::Machine;
+
+{
+    package My::Plack::Request;
+    use strict;
+    use warnings;
+
+    use parent 'Plack::Request';
+}
+
+my $app = Web::Machine->new(
+    resource      => 'Web::Machine::Resource',
+    request_class => 'My::Plack::Request',
+);
+
+my $request = $app->inflate_request({});
+
+isa_ok($request, 'My::Plack::Request');
+isa_ok($request, 'Plack::Request');
+
+ok(
+    exception {
+        Web::Machine->new(
+            resource      => 'Web::Machine::Resource',
+            request_class => $request,
+        );
+    },
+    'The constructor dies when request_class is not a module name...'
+);
+
+like(
+    exception {
+        Web::Machine->new(
+            resource      => 'Web::Machine::Resource',
+            request_class => 'Web::Machine',
+        );
+    },
+    qr/must inherit from Plack::Request/,
+    '...or if the request_class class does not inherit from Plack::Request'
+);
+
+done_testing;


### PR DESCRIPTION
The optional request_class constructor allows a class that inherits from
Plack::Request to be specified in the Web::Machine constructor.
