### PR TITLE
Declare minimum perl version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -50,3 +50,9 @@ stopwords = webmachine
 [Prereqs / DevelopRequires]
 JSON::XS = 0
 Path::Class = 0
+
+[Prereqs]
+perl = 5.006
+
+[Prereqs / TestRequires]
+perl = 5.008


### PR DESCRIPTION
I've been assigned Web::Machine this month as part of the [CPAN PR Challenge](http://cpan-prc.org/) - thanks for participating!

One of the hit points for dists in the challenge is the presence of CPANTS kwalitee failures. This PR addresses the [lack of a minimum perl version in the metadata](https://cpants.cpanauthors.org/kwalitee/meta_yml_declares_perl_version). As the test suite appears to require a more recent perl (5.8.0 because of the lexical filehandles) both versions have now been included in the dist.ini.