### PR TITLE
Set allowable warning in test suite - issue #36

### DIFF
--- a/t/010-resource-tests.t
+++ b/t/010-resource-tests.t
@@ -7,7 +7,7 @@ use lib 't/010-resources/';
 
 use Test::More;
 use Test::Fatal;
-use Test::FailWarnings;
+use Test::FailWarnings -allow_from => [ qw/Cookie::Baker/ ];
 
 use Plack::Request;
 use Plack::Response;

--- a/t/012-warning-no-etag.t
+++ b/t/012-warning-no-etag.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/010-resources/';
 
 use Test::More;
-use Test::FailWarnings;
+use Test::FailWarnings -allow_from => [ qw/Cookie::Baker/ ];
 
 use Plack::Request;
 use Plack::Response;


### PR DESCRIPTION
This implements the solution proposed in issue #36 to prevent test failures for users which only have the pure perl version of Cookie::Baker.